### PR TITLE
fix: update dependabot/fetch-metadata to v3 in auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3.0.0
 
       - name: Approve PR
         run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
The Dependabot auto-merge workflow was failing on the approval step because it was using `dependabot/fetch-metadata@v2` which is deprecated for Node.js 20. Updated to `v3.0.0`. This should fix the failing auto-merge checks on PRs #13, #14, and #15.